### PR TITLE
Handle that jenkins base url ends with a slash

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/JenkinsWebhook.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/JenkinsWebhook.java
@@ -31,7 +31,7 @@ public class JenkinsWebhook implements AsyncPostReceiveRepositoryHook, Repositor
 	        try {
 	        	String query = String.format("url=%s", 
 	        		     URLEncoder.encode(gitRepoUrl, "UTF-8"));
-		        String url = jenkinsBase + "/git/notifyCommit?" + query;
+		        String url = jenkinsBase.replaceFirst("/$", "") + "/git/notifyCommit?" + query;
 	            URLConnection connection = new URL(url).openConnection();
 	            connection.getInputStream();
 	        } catch (Exception e) {


### PR DESCRIPTION
removes slash at the end of jenkins base url (if any) before appending the rest of the url for triggering commit notification to jenkins
