### PR TITLE
Mention of Poll SCM in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ After making commits to Stash, notify Jenkins that a new build has been created.
 
 ## Requirements
 
-+  **Git Plugin** - Jenkins needs to have the [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin) installed in Jenkins
++  **Git Plugin** - Jenkins needs to have the [Git Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Git+Plugin) installed in Jenkins and the Poll SCM option must be enabled
 
 ## Setup
 


### PR DESCRIPTION
I just setup this plugin for the first time and was stumped until I enabled the 'Poll SCM' option in Jenkins, which seems counter intuitive to me since I don't really want to poll.  This little change adds documentation so hopefully others won't be stumped. 
