### PR TITLE
Fixed Urls not ending with / beeing ignored as the jenkins notify url co...

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/JenkinsWebhook.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/JenkinsWebhook.java
@@ -59,6 +59,12 @@ public class JenkinsWebhook implements AsyncPostReceiveRepositoryHook, Repositor
     		throws Exception {
     	String query = String.format("url=%s", 
     			URLEncoder.encode(gitRepoUrl, "UTF-8"));
+
+        // in case of jenkins url looking like http://somehost:8081 and therefore not ending with a slash
+        if (!jenkinsBase.endsWith("/")) {
+                jenkinsBase += "/";
+        }
+
     	return jenkinsBase.replaceFirst("/$", "") + "/git/notifyCommit?" + query;
     }
 


### PR DESCRIPTION
Urls not ending with a slash were ignored previously without any error message.

This appends a / to all urls not ending with /.
