### PR TITLE
Fixes Nerdwin15/stash-jenkins-postreceive-webhook#78

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
@@ -87,7 +87,8 @@ public class JenkinsResource extends RestResource {
   public Map<String, Object> test(@Context Repository repository,
         @FormParam(Notifier.JENKINS_BASE) String jenkinsBase,
         @FormParam(Notifier.CLONE_URL) String cloneUrl,
-        @FormParam(Notifier.IGNORE_CERTS) boolean ignoreCerts) {
+        @FormParam(Notifier.IGNORE_CERTS) boolean ignoreCerts,
+        @FormParam(Notifier.OMIT_HASH_CODE) boolean omitHashCode) {
     
     if (jenkinsBase == null || cloneUrl == null) {
       Map<String, Object> map = new HashMap<String, Object>();
@@ -104,7 +105,7 @@ public class JenkinsResource extends RestResource {
      *   handle this in notify
      */
     NotificationResult result = notifier.notify(repository, jenkinsBase, 
-        ignoreCerts, cloneUrl, null, null);
+        ignoreCerts, cloneUrl, null, null, omitHashCode);
     log.debug("Got response from jenkins: {}", result);
 
     // Shouldn't have to do this but the result isn't being marshalled correctly

--- a/src/main/resources/static/jenkins.js
+++ b/src/main/resources/static/jenkins.js
@@ -18,6 +18,7 @@ define('plugin/jenkins/test', [
             $cloneUrl = $("#gitRepoUrl"),
             $cloneType = $("#cloneType"),
             $ignoreCerts = $("#ignoreCerts"),
+            $omitHashCode = $("#omitHashCode"),
             $status,
             defaultUrls;
 
@@ -36,13 +37,13 @@ define('plugin/jenkins/test', [
                 $button.prop("disabled", "disabled").addClass("disabled");
             }
         }
-        
+
         ajax.rest({
         	url: resourceUrl('config')
         }).success(function(data) {
         	defaultUrls = data;
         });
-        
+
         $cloneType.change(function() {
         	var val = $(this).val();
         	if (val == "ssh") {
@@ -51,7 +52,7 @@ define('plugin/jenkins/test', [
         		$cloneUrl.val( defaultUrls.http );
         	}
         });
-        
+
         if ($cloneUrl.val() != "") {
         	var cloneUrl = $cloneUrl.val();
         	if (cloneUrl.search("ssh") === 0) {
@@ -70,7 +71,8 @@ define('plugin/jenkins/test', [
                 data: {
                     'jenkinsBase': [$jenkinsBase.val()],
                     'gitRepoUrl': [$cloneUrl.val()],
-                    'ignoreCerts': [$ignoreCerts.attr('checked') ? "TRUE" : "FALSE"]
+                    'ignoreCerts': [$ignoreCerts.attr('checked') ? "TRUE" : "FALSE"],
+                    'omitHashCode': [$omitHashCode.attr('checked') ? "TRUE" : "FALSE"]
                 }
             }).always(function () {
                 setDeleteButtonEnabled(true)

--- a/src/main/resources/static/jenkins.soy
+++ b/src/main/resources/static/jenkins.soy
@@ -43,7 +43,19 @@
         {/param}
         {param description: stash_i18n('stash.webhook.ignoreCerts.description', 'When connecting to Jenkins, allow all certificates to be accepted, including self-signed certs') /}
     {/call}
-    
+
+    {call widget.aui.form.checkbox}
+        {param id: 'omitHashCode' /}
+        {param checked: $config['omitHashCode'] /}
+        {param labelContent}
+            {stash_i18n('stash.webhook.omitHashCode.label', 'Omit SHA1 Hash Code')}
+        {/param}
+        {param labelHtml}
+            {stash_i18n('stash.webhook.omitHashCode.label', 'Omit SHA1 Hash Code')}
+        {/param}
+        {param description: stash_i18n('stash.webhook.omitHashCode.description', 'Do not send the commit\'s SHA1 hash code to Jenkins') /}
+    {/call}
+
     {call widget.aui.form.field}
         {param id: 'test-form' /}
         {param labelContent: stash_i18n('stash.webhook.test', 'Configuration check') /}
@@ -57,11 +69,11 @@
             {/call}
         {/param}
     {/call}
-    
+
     <hr />
-    
+
     <h3>{stash_i18n('stash.webhook.advancedConfiguration.label', 'Advanced Configuration')}</h3>
-      
+
     {call aui.form.textField}
         {param id: 'ignoreCommitters' /}
         {param value: $config['ignoreCommitters'] /}
@@ -87,7 +99,7 @@
         </div>
         {(($errors) ? '<div class="error">' + $errors['branchOptionsBranches'] + '</div>' : '')|noAutoescape}
     </div>
-    
+
     <script>
         require('plugin/jenkins/test').onReady();
     </script>

--- a/src/test/java/com/nerdwin15/stash/webhook/rest/JenkinsResourceTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/rest/JenkinsResourceTest.java
@@ -33,6 +33,7 @@ public class JenkinsResourceTest {
 
   private static final String JENKINS_BASE = "http://jenkins.localhost/jenkins";
   private static final boolean IGNORE_CERTS = false;
+  private static final boolean OMIT_HASH_CODE = false;
 
   private static final String HTTP_URL = 
       "https://stash.localhost/stash/scm/test/test.git";
@@ -75,7 +76,7 @@ public class JenkinsResourceTest {
   @Test
   public void shouldFailWhenJenkinsBaseNullProvidedToTest() {
     Map<String, Object> result = 
-        resource.test(repository, JENKINS_BASE, null, IGNORE_CERTS);
+        resource.test(repository, JENKINS_BASE, null, IGNORE_CERTS, OMIT_HASH_CODE);
     assertFalse((Boolean) result.get("successful"));
   }
 
@@ -86,7 +87,7 @@ public class JenkinsResourceTest {
   @Test
   public void shouldFailWhenCloneUrlNullProvidedToTest() {
     Map<String, Object> result = 
-        resource.test(repository, JENKINS_BASE, null, IGNORE_CERTS);
+        resource.test(repository, JENKINS_BASE, null, IGNORE_CERTS, OMIT_HASH_CODE);
     assertFalse((Boolean) result.get("successful"));
   }
   


### PR DESCRIPTION
![79](https://cloud.githubusercontent.com/assets/205553/4463515/9d2d9276-48cb-11e4-9114-56a661910504.png)

Hello, this allows omitting the SHA1 hash code of the commit. This is a workaround until https://issues.jenkins-ci.org/browse/JENKINS-24133 is fixed. Tested on Stash 2.9.4 and Stash 3.3.1.
