### PR TITLE
Don't hardcode the stash pull url at config time

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/PostReceiveHook.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/PostReceiveHook.java
@@ -36,11 +36,22 @@ public class PostReceiveHook implements AsyncPostReceiveRepositoryHook,
       errors.addFieldError(Notifier.JENKINS_BASE, 
           "The url for your Jenkins instance is required.");
     }
-    
-    final String cloneType = settings.getString(Notifier.CLONE_URL);
+
+    final String cloneType = settings.getString(Notifier.CLONE_TYPE);
     if (Strings.isNullOrEmpty(cloneType)) {
-      errors.addFieldError(Notifier.CLONE_URL, 
-          "The repository clone url is required");
+        errors.addFieldError(Notifier.CLONE_TYPE,
+                "The repository clone type is required");
+    } else if (!cloneType.equals("http") && !cloneType.equals("ssh") && !cloneType.equals("custom")) {
+        errors.addFieldError(Notifier.CLONE_TYPE,
+                "The repository clone type is invalid");
+    }
+    
+    final String cloneUrl = settings.getString(Notifier.CLONE_URL);
+    if (cloneType == null || cloneType.equals("custom")) {
+        if (Strings.isNullOrEmpty(cloneUrl)) {
+          errors.addFieldError(Notifier.CLONE_URL,
+              "The repository clone url is required");
+        }
     }
     
     final String branchSelection = settings.getString(Notifier.BRANCH_OPTIONS);

--- a/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
@@ -77,6 +77,7 @@ public class JenkinsResource extends RestResource {
    * Fire off the test of the Jenkins configuration
    * @param repository The repository to base the notification on
    * @param jenkinsBase The base URL for the Jenkins instance
+   * @param cloneType The clone type for repository cloning
    * @param cloneUrl The url used for repository cloning
    * @param ignoreCerts True if all certs should be accepted.
    * @return The response to send back to the user.
@@ -86,11 +87,12 @@ public class JenkinsResource extends RestResource {
   @Produces(MediaType.APPLICATION_JSON)
   public Map<String, Object> test(@Context Repository repository,
         @FormParam(Notifier.JENKINS_BASE) String jenkinsBase,
+        @FormParam(Notifier.CLONE_TYPE) String cloneType,
         @FormParam(Notifier.CLONE_URL) String cloneUrl,
         @FormParam(Notifier.IGNORE_CERTS) boolean ignoreCerts,
         @FormParam(Notifier.OMIT_HASH_CODE) boolean omitHashCode) {
     
-    if (jenkinsBase == null || cloneUrl == null) {
+    if (jenkinsBase == null || cloneType == null || (cloneType.equals("custom") && cloneUrl == null)) {
       Map<String, Object> map = new HashMap<String, Object>();
       map.put("successful", false);
       map.put("message", "Settings must be configured");
@@ -105,7 +107,7 @@ public class JenkinsResource extends RestResource {
      *   handle this in notify
      */
     NotificationResult result = notifier.notify(repository, jenkinsBase, 
-        ignoreCerts, cloneUrl, null, null, omitHashCode);
+        ignoreCerts, cloneType, cloneUrl, null, null, omitHashCode);
     log.debug("Got response from jenkins: {}", result);
 
     // Shouldn't have to do this but the result isn't being marshalled correctly

--- a/src/main/resources/static/jenkins.js
+++ b/src/main/resources/static/jenkins.js
@@ -38,29 +38,41 @@ define('plugin/jenkins/test', [
             }
         }
 
+        function setCloneUrl(val) {
+            if (val == "ssh") {
+        		$cloneUrl.val( defaultUrls.ssh );
+                $cloneUrl.prop("disabled", "disabled").addClass("disabled");
+        	} else if (val == "http") {
+        		$cloneUrl.val( defaultUrls.http );
+                $cloneUrl.prop("disabled", "disabled").addClass("disabled");
+        	} else {
+                $cloneUrl.removeProp("disabled").removeClass("disabled");
+            }
+        }
+
+        $cloneType.change(function() {
+        	setCloneUrl($(this).val());
+        });
+
         ajax.rest({
         	url: resourceUrl('config')
         }).success(function(data) {
         	defaultUrls = data;
+            
+            if ($cloneUrl.val() != "") {
+                var cloneUrl = $cloneUrl.val();
+                if (cloneUrl == defaultUrls.ssh) {
+                    $cloneType.find("option[value='ssh']").attr("selected", "selected");
+                } else if (cloneUrl == defaultUrls.http) {
+                    $cloneType.find("option[value='http']").attr("selected", "selected");
+                } else {
+                    $cloneType.find("option[value='custom']").attr("selected", "selected");
+                }
+                $cloneType.trigger('change');
+            } else {
+                setCloneUrl($cloneType.val());
+            }
         });
-
-        $cloneType.change(function() {
-        	var val = $(this).val();
-        	if (val == "ssh") {
-        		$cloneUrl.val( defaultUrls.ssh );
-        	} else if (val == "http") {
-        		$cloneUrl.val( defaultUrls.http );
-        	}
-        });
-
-        if ($cloneUrl.val() != "") {
-        	var cloneUrl = $cloneUrl.val();
-        	if (cloneUrl.search("ssh") === 0) {
-        		$cloneType.find("option[value='ssh']").attr("selected", "selected");
-        	} else if (cloneUrl.search("http") === 0) {
-        		$cloneType.find("option[value='http']").attr("selected", "selected");
-        	}
-        }
 
         $button.click(function () {
             setStatus("Trying...", "green");
@@ -70,6 +82,7 @@ define('plugin/jenkins/test', [
                 type: 'POST',
                 data: {
                     'jenkinsBase': [$jenkinsBase.val()],
+                    'cloneType': [$cloneType.val()],
                     'gitRepoUrl': [$cloneUrl.val()],
                     'ignoreCerts': [$ignoreCerts.attr('checked') ? "TRUE" : "FALSE"],
                     'omitHashCode': [$omitHashCode.attr('checked') ? "TRUE" : "FALSE"]

--- a/src/main/resources/static/jenkins.soy
+++ b/src/main/resources/static/jenkins.soy
@@ -20,10 +20,10 @@
 
     <div class="field-group">
         <label for="gitRepoUrl">{stash_i18n('stash.webhook.repo.cloneUrl.label', 'Repo Clone URL')}</label>
-        <select class="select" id="cloneType" style="max-width: 90px">
-            <option value="">Select...</option>
-            <option value="http">HTTP</option>
-            <option value="ssh">SSH</option>
+        <select class="select" id="cloneType" name="cloneType" style="max-width: 90px">
+            <option value="http" {($config['cloneType'] == 'http') ? 'selected="selected"' : ''}>HTTP</option>
+            <option value="ssh" {($config['cloneType'] == 'ssh') ? 'selected="selected"' : ''}>SSH</option>
+            <option value="custom" {($config['cloneType'] != 'http' and $config['cloneType'] != 'ssh') ? 'selected="selected"' : ''}>Custom</option>
         </select>
         &nbsp;
         <input id="gitRepoUrl" style="max-width: 400px" class="text" type="text" name="gitRepoUrl" value="{($config['gitRepoUrl'] != null) ? $config['gitRepoUrl'] : ''}">

--- a/src/test/java/com/nerdwin15/stash/webhook/PostReceiveHookTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/PostReceiveHookTest.java
@@ -68,6 +68,28 @@ public class PostReceiveHookTest {
   }
 
   /**
+   * Validate that an error is added when the repo clone type is null
+   * @throws Exception
+   */
+  @Test
+  public void shouldAddErrorWhenCloneTypeNull() throws Exception {
+    when(settings.getString(Notifier.CLONE_TYPE)).thenReturn(null);
+    hook.validate(settings, errors, repo);
+    verify(errors).addFieldError(eq(Notifier.CLONE_TYPE), anyString());
+  }
+
+ /**
+   * Validate that an error is added when the repo clone type is invalid
+   * @throws Exception
+   */
+  @Test
+  public void shouldAddErrorWhenCloneTypeInvalid() throws Exception {
+    when(settings.getString(Notifier.CLONE_TYPE)).thenReturn("invalid");
+    hook.validate(settings, errors, repo);
+    verify(errors).addFieldError(eq(Notifier.CLONE_TYPE), anyString());
+  }
+
+  /**
    * Validate that an error is added when the repo clone url is null
    * @throws Exception
    */

--- a/src/test/java/com/nerdwin15/stash/webhook/rest/JenkinsResourceTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/rest/JenkinsResourceTest.java
@@ -76,18 +76,28 @@ public class JenkinsResourceTest {
   @Test
   public void shouldFailWhenJenkinsBaseNullProvidedToTest() {
     Map<String, Object> result = 
-        resource.test(repository, JENKINS_BASE, null, IGNORE_CERTS, OMIT_HASH_CODE);
+        resource.test(repository, null, "http", null, IGNORE_CERTS, OMIT_HASH_CODE);
     assertFalse((Boolean) result.get("successful"));
   }
 
   /**
-   * Validate that if a null repo clone url is provided, a BAD_REQUEST is 
-   * returned.
+   * Validate that if a null CloneType is provided, a BAD_REQUEST is returned.
+   */
+  @Test
+  public void shouldFailWhenCloneTypeNullProvidedToTest() {
+    Map<String, Object> result =
+        resource.test(repository, JENKINS_BASE, null, HTTP_URL, IGNORE_CERTS, OMIT_HASH_CODE);
+    assertFalse((Boolean) result.get("successful"));
+  }
+
+  /**
+   * Validate that if a null repo clone url is provided when the clone type 
+   * is set to CUSTOM, then a BAD_REQUEST is returned.
    */
   @Test
   public void shouldFailWhenCloneUrlNullProvidedToTest() {
     Map<String, Object> result = 
-        resource.test(repository, JENKINS_BASE, null, IGNORE_CERTS, OMIT_HASH_CODE);
+        resource.test(repository, JENKINS_BASE, "custom", null, IGNORE_CERTS, OMIT_HASH_CODE);
     assertFalse((Boolean) result.get("successful"));
   }
   


### PR DESCRIPTION
This change sets up the http-vs-ssh selection of the URL to be configurable, but the actual URL is only resolved when trying to do a notification. The main benefit of this is that repositories that are moved/renamed automatically pick up the change, but another benefit is that it makes it slightly easier to script up the default config when creating a new repository.

Custom urls are still permitted, in case there are users with special needs (eg jenkins not using the standard hostname because its behind a reverse proxy, or something)

Existing config is treated as 'custom', but auto-corrected when the hook config is saved. That means that any existing repositories will still have the hard-coded URL and so will NOT automatically update their URL when moved. (There's no easy way I could work out to do a data migration when the plugin was updated)