### PR TITLE
Make sure SSH is enabled before trying to get an SSH clone URL

### DIFF
--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -28,6 +28,7 @@
     <component key="jenkinsNotifier" class="com.nerdwin15.stash.webhook.Notifier"/>
     <component key="clientFactory" class="com.nerdwin15.stash.webhook.service.ConcreteHttpClientFactory"/>
     <component-import key="sshCloneUrlResolver" interface="com.atlassian.stash.ssh.api.SshCloneUrlResolver"/>
+    <component-import key="sshConfigurationService" interface="com.atlassian.stash.ssh.api.SshConfigurationService"/>
     
     <rest key="jenkins-rest" path="/jenkins" version="1.0">
         <dispatcher>REQUEST</dispatcher>


### PR DESCRIPTION
This is a quick fix for #101. The config endpoint simply returns an empty string for the SSH clone URL if SSH is disabled. I made no effort to disable the SSH option in the hook's settings UI. I tested this change on Stash 2.4.0, 3.0.0 and 3.5.1.