### PR TITLE
Trigger Button URL expects 'branches' rather than 'branch'

### DIFF
--- a/src/main/resources/static/jenkins-pr-triggerbutton.js
+++ b/src/main/resources/static/jenkins-pr-triggerbutton.js
@@ -8,7 +8,7 @@ define('plugin/jenkins/pr-triggerbutton', [
     return AJS.contextPath() + '/rest/jenkins/latest/projects/' 
       + pageState.getProject().getKey() + '/repos/' 
       + pageState.getRepository().getSlug() + '/triggerJenkins'
-      + '?branch=' + pageState.getPullRequest().getFromRef().getDisplayId()
+      + '?branches=' + pageState.getPullRequest().getFromRef().getDisplayId()
       + '&sha1=' + pageState.getPullRequest().getFromRef().getLatestChangeset();
   };
 


### PR DESCRIPTION
The URL formats visible in Notifier.java show that the attribute should be "branches" rather than "branch".  Manual tests hitting the corrected URLs show the notifications are successfully received in my Jenkins log.