### PR TITLE
Restore PR event handling

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/PullRequestEventListener.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/PullRequestEventListener.java
@@ -63,7 +63,7 @@ public class PullRequestEventListener {
       return;
     }
 
-    Get branch name from stash ref 'project/repo:refs/heads/master'
+    //Get branch name from stash ref 'project/repo:refs/heads/master'
     String strRef = event.getPullRequest().getFromRef().toString()
         .replaceFirst(".*refs/heads/", "");
     String strSha1 = event.getPullRequest().getFromRef().getLatestChangeset();

--- a/src/main/java/com/nerdwin15/stash/webhook/PullRequestEventListener.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/PullRequestEventListener.java
@@ -58,22 +58,22 @@ public class PullRequestEventListener {
    * @param event The event to be handled
    */
   protected void handleEvent(PullRequestEvent event) {
-//    if (settingsService.getSettings(event.getPullRequest().getToRef()
-//        .getRepository()) == null) {
-//      return;
-//    }
-//
-//    Get branch name from stash ref 'project/repo:refs/heads/master'
-//    String strRef = event.getPullRequest().getFromRef().toString()
-//        .replaceFirst(".*refs/heads/", "");
-//    String strSha1 = event.getPullRequest().getFromRef().getLatestChangeset();
-//
-//    EventContext context = new EventContext(event,
-//        event.getPullRequest().getToRef().getRepository(),
-//        event.getUser().getName());
-//
-//    if (filterChain.shouldDeliverNotification(context))
-//      notifier.notifyBackground(context.getRepository(), strRef, strSha1);
+    if (settingsService.getSettings(event.getPullRequest().getToRef()
+        .getRepository()) == null) {
+      return;
+    }
+
+    Get branch name from stash ref 'project/repo:refs/heads/master'
+    String strRef = event.getPullRequest().getFromRef().toString()
+        .replaceFirst(".*refs/heads/", "");
+    String strSha1 = event.getPullRequest().getFromRef().getLatestChangeset();
+
+    EventContext context = new EventContext(event,
+        event.getPullRequest().getToRef().getRepository(),
+        event.getUser().getName());
+
+    if (filterChain.shouldDeliverNotification(context))
+      notifier.notifyBackground(context.getRepository(), strRef, strSha1);
   }
   
 }

--- a/src/main/java/com/nerdwin15/stash/webhook/PullRequestEventListener.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/PullRequestEventListener.java
@@ -63,7 +63,6 @@ public class PullRequestEventListener {
       return;
     }
 
-    //Get branch name from stash ref 'project/repo:refs/heads/master'
     String strRef = event.getPullRequest().getFromRef().toString()
         .replaceFirst(".*refs/heads/", "");
     String strSha1 = event.getPullRequest().getFromRef().getLatestChangeset();


### PR DESCRIPTION
Restore the PR event handling method body.  Pull Requests are seeing no handling whatsoever (new creation, new commits added) right now.

Looking back at @loa's comments on the original commenting-out commit, it sounds like their use case would be better served by the Jenkins jobs' branch settings being tighter.  We need the notifications themselves as free as possible, and then it's up to the Jenkins jobs to know what to poll against (and thus choose to build or not).