### PR TITLE
Add ability to omit branch on jenkins notify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ build
 Icon?
 ehthumbs.db
 Thumbs.db
+.idea
+*.iml
 
 .classpath
 .project

--- a/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
@@ -95,8 +95,8 @@ public class Notifier implements DisposableBean {
   private static final Logger LOGGER = 
       LoggerFactory.getLogger(Notifier.class);
   private static final String BASE_URL = "%s/git/notifyCommit?url=%s";
-  private static final String HASH_PARAMETER = "&sha1=%s";
-  private static final String BRANCH_PARAMETER = "&branches=%s";
+  private static final String HASH_URL_PARAMETER = "&sha1=%s";
+  private static final String BRANCH_URL_PARAMETER = "&branches=%s";
 
   private final HttpClientFactory httpClientFactory;
   private final SettingsService settingsService;
@@ -259,9 +259,9 @@ public class Notifier implements DisposableBean {
     url.append(String.format(BASE_URL, jenkinsBase, urlEncode(cloneUrl)));
 
     if(strRef != null && !omitBranchName)
-      url.append(String.format(BRANCH_PARAMETER, strRef));
+      url.append(String.format(BRANCH_URL_PARAMETER, strRef));
     if(!omitHashCode)
-      url.append(String.format(HASH_PARAMETER, strSha1));
+      url.append(String.format(HASH_URL_PARAMETER, strSha1));
 
     return url.toString();
   }

--- a/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
@@ -73,6 +73,11 @@ public class Notifier implements DisposableBean {
   public static final String OMIT_HASH_CODE = "omitHashCode";
 
   /**
+   * Field name for the omit branch name property
+   */
+  public static final String OMIT_BRANCH_NAME = "omitBranchName";
+
+  /**
    * Field name for the ignore committers property
    */
   public static final String IGNORE_COMMITTERS = "ignoreCommitters";
@@ -89,9 +94,9 @@ public class Notifier implements DisposableBean {
 
   private static final Logger LOGGER = 
       LoggerFactory.getLogger(Notifier.class);
-  private static final String URL_SHORT = "%s/git/notifyCommit?url=%s";
-  private static final String URL = "%s/git/notifyCommit?url=%s&branches=%s&sha1=%s";
-  private static final String URL_NO_HASH = "%s/git/notifyCommit?url=%s&branches=%s";
+  private static final String BASE_URL = "%s/git/notifyCommit?url=%s";
+  private static final String HASH_PARAMETER = "&sha1=%s";
+  private static final String BRANCH_PARAMETER = "&branches=%s";
 
   private final HttpClientFactory httpClientFactory;
   private final SettingsService settingsService;
@@ -158,7 +163,8 @@ public class Notifier implements DisposableBean {
         settings.getString(CLONE_TYPE),
         settings.getString(CLONE_URL),
         strRef, strSha1,
-        settings.getBoolean(OMIT_HASH_CODE, false));
+        settings.getBoolean(OMIT_HASH_CODE, false),
+        settings.getBoolean(OMIT_BRANCH_NAME, false));
   }
 
   /**
@@ -171,18 +177,19 @@ public class Notifier implements DisposableBean {
    * @param strSha1 The commit's SHA1 hash code.
    * @param omitHashCode Defines whether the commit's SHA1 hash code is omitted
    *        in notification to Jenkins.
+   * @param omitBranchName Defines whether the commit's branch name is omitted
    * @return The notification result.
    */
   public @Nullable NotificationResult notify(@Nonnull Repository repo, //CHECKSTYLE:annot
       String jenkinsBase, boolean ignoreCerts, String cloneType, String cloneUrl,
-      String strRef, String strSha1, boolean omitHashCode) {
+      String strRef, String strSha1, boolean omitHashCode, boolean omitBranchName) {
     
     HttpClient client = null;
     String url;
 
     try {
         url = getUrl(repo, maybeReplaceSlash(jenkinsBase),
-            cloneType, cloneUrl, strRef, strSha1, omitHashCode);
+            cloneType, cloneUrl, strRef, strSha1, omitHashCode, omitBranchName);
     } catch (Exception e) {
         LOGGER.error("Error getting Jenkins URL", e);
         return new NotificationResult(false, null, e.getMessage());
@@ -227,7 +234,7 @@ public class Notifier implements DisposableBean {
    * @return The url to use for notifying Jenkins
    */
   protected String getUrl(final Repository repository, final String jenkinsBase,
-      final String cloneType, final String customCloneUrl, final String strRef, final String strSha1, boolean omitHashCode) {
+      final String cloneType, final String customCloneUrl, final String strRef, final String strSha1, boolean omitHashCode, boolean omitBranchName) {
       String cloneUrl = customCloneUrl;
     // Older installs won't have a cloneType value - treat as custom
     if (cloneType != null && !cloneType.equals("custom")) {
@@ -248,14 +255,17 @@ public class Notifier implements DisposableBean {
         }
     }
 
-    if (strRef == null)
-      return String.format(URL_SHORT, jenkinsBase, urlEncode(cloneUrl));
-    else if (omitHashCode)
-      return String.format(URL_NO_HASH, jenkinsBase, urlEncode(cloneUrl), strRef);
-    else 
-      return String.format(URL, jenkinsBase, urlEncode(cloneUrl), strRef, strSha1);
+    StringBuilder url = new StringBuilder();
+    url.append(String.format(BASE_URL, jenkinsBase, urlEncode(cloneUrl)));
+
+    if(strRef != null && !omitBranchName)
+      url.append(String.format(BRANCH_PARAMETER, strRef));
+    if(!omitHashCode)
+      url.append(String.format(HASH_PARAMETER, strSha1));
+
+    return url.toString();
   }
-  
+
   private static String urlEncode(String string) {
     try {
       return URLEncoder.encode(string, "UTF-8");

--- a/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
@@ -114,7 +114,7 @@ public class JenkinsResource extends RestResource {
      *   handle this in notify
      */
     NotificationResult result = notifier.notify(repository, jenkinsBase, 
-        ignoreCerts, cloneType, cloneUrl, null, null, omitHashCode);
+        ignoreCerts, cloneType, cloneUrl, null, null, omitHashCode, true);
     log.debug("Got response from jenkins: {}", result);
 
     // Shouldn't have to do this but the result isn't being marshalled correctly

--- a/src/main/resources/static/jenkins.soy
+++ b/src/main/resources/static/jenkins.soy
@@ -56,6 +56,18 @@
         {param description: stash_i18n('stash.webhook.omitHashCode.description', 'Do not send the commit\'s SHA1 hash code to Jenkins') /}
     {/call}
 
+    {call widget.aui.form.checkbox}
+        {param id: 'omitBranchName' /}
+        {param checked: $config['omitBranchName'] /}
+        {param labelContent}
+            {stash_i18n('stash.webhook.omitBranchName.label', 'Omit Branch Name')}
+        {/param}
+        {param labelHtml}
+            {stash_i18n('stash.webhook.omitBranchName.label', 'Omit Branch Name')}
+        {/param}
+        {param description: stash_i18n('stash.webhook.omitBranchName.description', 'Do not send the commit\'s branch name to Jenkins') /}
+    {/call}
+
     {call widget.aui.form.field}
         {param id: 'test-form' /}
         {param labelContent: stash_i18n('stash.webhook.test', 'Configuration check') /}

--- a/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
@@ -354,8 +354,8 @@ public class NotifierTest {
   }
 
   /**
-   * Validates that the correct path is used, even when a trailing slash
-   * is provided on the Jenkins Base URL
+   * Validates that the correct path is used when the omitBranchName option
+   * is on
    * @throws Exception
    */
   @Test
@@ -374,6 +374,30 @@ public class NotifierTest {
         + "url=http%3A%2F%2Fsome.stash.com%2Fscm%2Ffoo%2Fbar.git"
         + "&sha1=sha1",
         captor.getValue().getURI().toString());
-    }
+  }
+
+  /**
+   * Validates that the correct path is used when the omitBranchName option
+   * is off
+   * @throws Exception
+   */
+  @Test
+  public void shouldCallTheCorrectURLWithOmitBranchNameOff()
+    throws Exception {
+    when(settings.getBoolean(Notifier.OMIT_BRANCH_NAME, false)).thenReturn(false);
+    notifier.notify(repo, "refs/heads/master", "sha1");
+
+    ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
+
+   verify(httpClientFactory, times(1)).getHttpClient(false, false);
+   verify(httpClient, times(1)).execute(captor.capture());
+   verify(connectionManager, times(1)).shutdown();
+
+   assertEquals("http://localhost.jenkins/git/notifyCommit?"
+       + "url=http%3A%2F%2Fsome.stash.com%2Fscm%2Ffoo%2Fbar.git"
+       + "&branches=refs/heads/master"
+       + "&sha1=sha1",
+       captor.getValue().getURI().toString());
+  }
 
 }

--- a/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
@@ -352,5 +352,28 @@ public class NotifierTest {
         + "&sha1=sha1",
         captor.getValue().getURI().toString());
   }
-    
+
+  /**
+   * Validates that the correct path is used, even when a trailing slash
+   * is provided on the Jenkins Base URL
+   * @throws Exception
+   */
+  @Test
+  public void shouldCallTheCorrectURLWithOmitBranchNameOn()
+    throws Exception {
+    when(settings.getBoolean(Notifier.OMIT_BRANCH_NAME, false)).thenReturn(true);
+    notifier.notify(repo, "refs/heads/master", "sha1");
+
+    ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
+
+    verify(httpClientFactory, times(1)).getHttpClient(false, false);
+    verify(httpClient, times(1)).execute(captor.capture());
+    verify(connectionManager, times(1)).shutdown();
+
+    assertEquals("http://localhost.jenkins/git/notifyCommit?"
+        + "url=http%3A%2F%2Fsome.stash.com%2Fscm%2Ffoo%2Fbar.git"
+        + "&sha1=sha1",
+        captor.getValue().getURI().toString());
+    }
+
 }


### PR DESCRIPTION
This addresses #96.  It allows people to opt out of including the branch name in the jenkins notify.  