### PR TITLE
Switch from deprecated HttpClient API and allow Client Certs for Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ Once installed, follow these steps:
 -  Submit the form.
 -  Commit some code and watch it trigger a build!
 
+## Keystores when you have client certificates
+
+If you have a client certificate based security model in front of your Jenkins instance you can now
+add key material into the HTTP call.
+
+In order to do this you need to add the following to your stash-config.properties
+
+    plugin.stash-webhook-jenkins.keyStore=/path/to/keystore
+    plugin.stash-webhook-jenkins.keyStoreType=<type i.e.PKCS12>
+    plugin.stash-webhook-jenkins.keyStorePassword=<password for keystore>
+
 ## Troubleshooting
 
 - Check your log file for any exceptions

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.nerdwin15.stash</groupId>
     <artifactId>stash-webhook-jenkins</artifactId>
-    <version>2.7.0</version>
+    <version>2.8.0-SNAPSHOT</version>
 
     <organization>
         <name>Nerdwin15</name>

--- a/pom.xml
+++ b/pom.xml
@@ -171,10 +171,10 @@
     </build>
 
     <properties>
-        <stash.version>2.4.0</stash.version>
-        <stash.data.version>2.4.0</stash.data.version>
+        <stash.version>3.10.2</stash.version>
+        <stash.data.version>3.10.2</stash.data.version>
         <stash.containerId>tomcat7x</stash.containerId>
-        <amps.version>5.0.6</amps.version>
+        <amps.version>5.0.13</amps.version>
         <plugin.testrunner.version>1.1.1</plugin.testrunner.version>
         <powermock.version>1.4.9</powermock.version>
     </properties>

--- a/src/main/java/com/nerdwin15/stash/webhook/ClientKeyStore.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/ClientKeyStore.java
@@ -1,0 +1,55 @@
+package com.nerdwin15.stash.webhook;
+
+import com.atlassian.stash.server.ApplicationPropertiesService;
+
+import java.io.FileInputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+
+/**
+ * A keystore based on the definition from the
+ * application properties
+ */
+public class ClientKeyStore {
+
+    private KeyStore keyStore = null;
+    private char[] password = null;
+
+    public ClientKeyStore(ApplicationPropertiesService applicationPropertiesService) {
+        try {
+            // We need to allow client certs to be presented to the server, we
+            // will allow the system administrator to register a key store
+            // and password that we can load
+            if (applicationPropertiesService.getPluginProperty("keyStore") != null) {
+                keyStore = getKeyStore(applicationPropertiesService.getPluginProperty("keyStoreType"));
+
+
+                if (applicationPropertiesService.getPluginProperty("keyStorePassword") != null)
+                    password = applicationPropertiesService.getPluginProperty("keyStorePassword").toCharArray();
+
+                keyStore.load(new FileInputStream(applicationPropertiesService.getPluginProperty("keyStore")), password);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to build keystore", e);
+        }
+    }
+
+    public KeyStore getKeyStore() {
+        return keyStore;
+    }
+
+    public char[] getPassword() {
+        return password;
+    }
+
+    public boolean isAvailable() {
+        return keyStore != null;
+    }
+
+    private KeyStore getKeyStore(String keyStoreType) throws KeyStoreException {
+        if (keyStoreType != null)
+            return KeyStore.getInstance(keyStoreType);
+        else
+            return KeyStore.getInstance(KeyStore.getDefaultType());
+    }
+}

--- a/src/main/java/com/nerdwin15/stash/webhook/ClientKeyStore.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/ClientKeyStore.java
@@ -12,6 +12,12 @@ import java.security.KeyStoreException;
  */
 public class ClientKeyStore {
 
+    public final static String KEYSTORE_KEY = "plugin.stash-webhook-jenkins.keyStore";
+    public final static String KEYSTORE_TYPE_KEY = "plugin.stash-webhook-jenkins.keyStoreType";
+    public final static String KEYSTORE_PASSWORD_KEY = "plugin.stash-webhook-jenkins.keyStorePassword";
+
+
+
     private KeyStore keyStore = null;
     private char[] password = null;
 
@@ -20,14 +26,15 @@ public class ClientKeyStore {
             // We need to allow client certs to be presented to the server, we
             // will allow the system administrator to register a key store
             // and password that we can load
-            if (applicationPropertiesService.getPluginProperty("keyStore") != null) {
-                keyStore = getKeyStore(applicationPropertiesService.getPluginProperty("keyStoreType"));
+            System.out.println("Key store = "+applicationPropertiesService.getPluginProperty(KEYSTORE_KEY));
 
+            if (applicationPropertiesService.getPluginProperty(KEYSTORE_KEY) != null) {
+                keyStore = getKeyStore(applicationPropertiesService.getPluginProperty(KEYSTORE_TYPE_KEY));
 
-                if (applicationPropertiesService.getPluginProperty("keyStorePassword") != null)
-                    password = applicationPropertiesService.getPluginProperty("keyStorePassword").toCharArray();
+                if (applicationPropertiesService.getPluginProperty(KEYSTORE_PASSWORD_KEY) != null)
+                    password = applicationPropertiesService.getPluginProperty(KEYSTORE_PASSWORD_KEY).toCharArray();
 
-                keyStore.load(new FileInputStream(applicationPropertiesService.getPluginProperty("keyStore")), password);
+                keyStore.load(new FileInputStream(applicationPropertiesService.getPluginProperty(KEYSTORE_KEY)), password);
             }
         } catch (Exception e) {
             throw new RuntimeException("Unable to build keystore", e);

--- a/src/main/java/com/nerdwin15/stash/webhook/ClientKeyStore.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/ClientKeyStore.java
@@ -26,8 +26,6 @@ public class ClientKeyStore {
             // We need to allow client certs to be presented to the server, we
             // will allow the system administrator to register a key store
             // and password that we can load
-            System.out.println("Key store = "+applicationPropertiesService.getPluginProperty(KEYSTORE_KEY));
-
             if (applicationPropertiesService.getPluginProperty(KEYSTORE_KEY) != null) {
                 keyStore = getKeyStore(applicationPropertiesService.getPluginProperty(KEYSTORE_TYPE_KEY));
 

--- a/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
@@ -12,6 +12,7 @@ import java.util.concurrent.Future;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.atlassian.stash.server.ApplicationPropertiesService;
 import com.atlassian.util.concurrent.ThreadFactories;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -104,20 +105,23 @@ public class Notifier implements DisposableBean {
   private final NavBuilder navBuilder;
   private final SecurityService securityService;
   private final SshCloneUrlResolver sshCloneUrlResolver;
+  private final ApplicationPropertiesService applicationPropertiesService;
 
-  /**
+    /**
    * Create a new instance
    * @param settingsService Service used to get webhook settings
    * @param httpClientFactory Factory to generate HttpClients
    * @param navBuilder navBuilder to generate http urls
    * @param securityService securityService
    * @param sshCloneUrlResolver ssh clone URL resolver
+   * @param applicationPropertiesService the application properties service
    */
   public Notifier(SettingsService settingsService,
       HttpClientFactory httpClientFactory,
       NavBuilder navBuilder,
       SecurityService securityService,
-      SshCloneUrlResolver sshCloneUrlResolver) {
+      SshCloneUrlResolver sshCloneUrlResolver,
+      ApplicationPropertiesService applicationPropertiesService) {
     
     this.httpClientFactory = httpClientFactory;
     this.settingsService = settingsService;
@@ -125,6 +129,7 @@ public class Notifier implements DisposableBean {
     this.navBuilder = navBuilder;
     this.securityService = securityService;
     this.sshCloneUrlResolver = sshCloneUrlResolver;
+    this.applicationPropertiesService = applicationPropertiesService;
   }
 
   /**
@@ -202,7 +207,7 @@ public class Notifier implements DisposableBean {
 
     try {
       client = httpClientFactory.getHttpClient(url.startsWith("https"), 
-          ignoreCerts);
+          ignoreCerts, new ClientKeyStore(applicationPropertiesService));
 
       HttpResponse response = client.execute(new HttpGet(url));
       LOGGER.debug("Successfully triggered jenkins with url '{}': ", url);

--- a/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactory.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactory.java
@@ -1,103 +1,164 @@
 package com.nerdwin15.stash.webhook.service;
 
-import java.net.ProxySelector;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
+import org.apache.http.client.HttpClient;
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.ssl.TrustStrategy;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-
-import org.apache.http.client.HttpClient;
-import org.apache.http.conn.scheme.PlainSocketFactory;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.scheme.SchemeRegistry;
-import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.conn.BasicClientConnectionManager;
-import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.*;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 
 /**
  * An implementation of the {@link HttpClientFactory} that returns a
  * DefaultHttpClient that is either not configured at all (non-ssl and default
  * trusts) or configured to accept all certificates.  If told to accept all
  * certificates, an unsafe X509 trust manager is used.
- * 
+ * <p>
  * If setup of the "trust-all" HttpClient fails, a non-configured HttpClient
  * is returned.
- * 
- * @author Michael Irwin (mikesir87)
  *
+ * @author Michael Irwin (mikesir87)
+ * @author Philip Dodds (pdodds)
  */
 public class ConcreteHttpClientFactory implements HttpClientFactory {
 
-  private static final Integer HTTP_PORT = 80;
-  private static final Integer HTTPS_PORT = 443;
-  
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public HttpClient getHttpClient(Boolean usingSsl, Boolean trustAllCerts) 
-      throws Exception {
-    return createHttpClient(usingSsl && trustAllCerts);
-  }
+    private static final Integer HTTP_PORT = 80;
+    private static final Integer HTTPS_PORT = 443;
+    private KeyStore keyStore;
 
-  /**
-   * Create a new HttpClient.
-   * @param useConfigured True if the client should be configured to accept any
-   * certificate.
-   * @return The requested HttpClient
-   * @throws Exception
-   */
-  protected HttpClient createHttpClient(boolean useConfigured) throws Exception {
-    SchemeRegistry schemeRegistry;
-    DefaultHttpClient client;
-    if (useConfigured) {
-        SSLContext sslContext = createContext();
-        schemeRegistry = createScheme(sslContext);
-        client = new DefaultHttpClient(
-            new BasicClientConnectionManager(schemeRegistry));
-    } else {
-        client = new DefaultHttpClient();
-        schemeRegistry = client.getConnectionManager().getSchemeRegistry();
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpClient getHttpClient(Boolean usingSsl, Boolean trustAllCerts)
+            throws Exception {
+        return createHttpClient(usingSsl && trustAllCerts);
     }
 
-    client.setRoutePlanner(new ProxySelectorRoutePlanner(schemeRegistry,
-        ProxySelector.getDefault()));
-    return client;
-  }
+    /**
+     * Create a new HttpClient.
+     *
+     * @param useConfigured True if the client should be configured to accept any
+     *                      certificate.
+     * @return The requested HttpClient
+     * @throws Exception
+     */
+    protected HttpClient createHttpClient(boolean useConfigured) throws Exception {
 
-  /**
-   * Creates an SSL context
-   * @return The SSL context
-   * @throws NoSuchAlgorithmException
-   * @throws KeyManagementException
-   */
-  protected SSLContext createContext() throws NoSuchAlgorithmException, 
-      KeyManagementException {
-    SSLContext sslContext = SSLContext.getInstance("TLS");
-    sslContext.init(
-        null, 
-        new TrustManager[] { new UnsafeX509TrustManager() }, 
-        new SecureRandom());
-    return sslContext;
-  }
+        HttpClientBuilder builder = HttpClientBuilder.create();
 
-  /**
-   * Creates the SSL SchemeRegistry
-   * @param sslContext The SSL Context the scheme registry should use.
-   * @return The SSL SchemeRegistry
-   * @throws Exception
-   */
-  protected SchemeRegistry createScheme(SSLContext sslContext) 
-      throws Exception {
-    SchemeRegistry schemeRegistry = new SchemeRegistry();
-    schemeRegistry.register(
-        new Scheme("https", HTTPS_PORT, new SSLSocketFactory(sslContext)));
-    schemeRegistry.register(
-        new Scheme("http", HTTP_PORT, PlainSocketFactory.getSocketFactory()));
-    return schemeRegistry;
-  }
+        try {
+            SSLConnectionSocketFactory sslConnSocketFactory
+                    = new SSLConnectionSocketFactory(buildSslContext(useConfigured));
+            builder.setSSLSocketFactory(sslConnSocketFactory);
 
+            Registry<ConnectionSocketFactory> registry
+                    = RegistryBuilder.<ConnectionSocketFactory>create()
+                    .register("https", sslConnSocketFactory)
+                    .build();
+
+            HttpClientConnectionManager ccm
+                    = new BasicHttpClientConnectionManager(registry);
+
+            builder.setConnectionManager(ccm);
+        } catch (NoSuchAlgorithmException nsae) {
+            throw new RuntimeException("Unable to connect to Jenkins due to algorithm exception", nsae);
+        } catch (KeyManagementException kme) {
+            throw new RuntimeException("Unable to connect to Jenkins due to key management exception", kme);
+        } catch (KeyStoreException kse) {
+            throw new RuntimeException("Unable to connect to Jenkins due to key store exception", kse);
+
+        }
+
+        return builder.build();
+
+    }
+
+    /**
+     * Prepare the SSL Context,  this will determine whether to ignore the unverified
+     * and also can look to see if an environment setting is going to cause us to load
+     * a keystore
+     *
+     * @param ignoreUnverifiedSSL
+     * @return the updated SSL context
+     * @throws UnrecoverableKeyException
+     * @throws NoSuchAlgorithmException
+     * @throws KeyStoreException
+     * @throws KeyManagementException
+     * @throws KeyStoreException
+     */
+    private SSLContext buildSslContext(boolean ignoreUnverifiedSSL) throws UnrecoverableKeyException, NoSuchAlgorithmException, KeyStoreException, KeyManagementException, KeyStoreException, IOException, CertificateException {
+
+        SSLContextBuilder customContext = SSLContexts.custom();
+        if (ignoreUnverifiedSSL) {
+            customContext = ignoreUnverifiedSSL(customContext);
+        }
+
+        System.out.println("Checking for keystore = "+System.getenv("STASH_KEYSTORE_PATH"));
+
+
+        // We need to allow client certs to be presented to the server, we
+        // will allow the system administrator to register a key store
+        // and password that we can load
+        if (System.getenv("STASH_KEYSTORE_PATH") != null) {
+            KeyStore ks = getKeyStore();
+
+            System.out.println("Loading keystore "+System.getenv("STASH_KEYSTORE_PATH"));
+
+            char[] password = null;
+            if (System.getenv("STASH_KEYSTORE_PASSWORD") != null)
+                password = System.getenv("STASH_KEYSTORE_PASSWORD").toCharArray();
+
+            ks.load(new FileInputStream(System.getenv("STASH_KEYSTORE_PATH")), password);
+
+            customContext.loadKeyMaterial(ks,password);
+        }
+
+
+        return customContext.build();
+    }
+
+    /**
+     * Setup SSL context to ignore unverified SSL connections
+     *
+     * @param customContext
+     * @return
+     * @throws KeyStoreException
+     * @throws NoSuchAlgorithmException
+     */
+    public SSLContextBuilder ignoreUnverifiedSSL(SSLContextBuilder customContext) throws KeyStoreException, NoSuchAlgorithmException {
+        TrustStrategy easyStrategy = new TrustStrategy() {
+            public boolean isTrusted(X509Certificate[] chain, String authType) {
+                return true;
+            }
+        };
+        customContext = customContext
+                .loadTrustMaterial(null, easyStrategy);
+
+        return customContext;
+    }
+
+    /**
+     * Get a local keystore,  based on the default type or the type specified
+     *
+     * @return
+     * @throws KeyStoreException
+     */
+    public KeyStore getKeyStore() throws KeyStoreException {
+        if (System.getenv("STASH_KEYSTORE_TYPE") != null)
+            return KeyStore.getInstance(System.getenv("STASH_KEYSTORE_TYPE"));
+        else
+            return KeyStore.getInstance(KeyStore.getDefaultType());
+    }
 }

--- a/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactory.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactory.java
@@ -43,42 +43,45 @@ public class ConcreteHttpClientFactory implements HttpClientFactory {
     @Override
     public HttpClient getHttpClient(Boolean usingSsl, Boolean trustAllCerts)
             throws Exception {
-        return createHttpClient(usingSsl && trustAllCerts);
+        return createHttpClient(usingSsl, trustAllCerts);
     }
 
     /**
      * Create a new HttpClient.
      *
+     *
+     * @param usingSsl using SSL
      * @param useConfigured True if the client should be configured to accept any
      *                      certificate.
      * @return The requested HttpClient
      * @throws Exception
      */
-    protected HttpClient createHttpClient(boolean useConfigured) throws Exception {
+    protected HttpClient createHttpClient(Boolean usingSsl, boolean useConfigured) throws Exception {
 
         HttpClientBuilder builder = HttpClientBuilder.create();
 
-        try {
-            SSLConnectionSocketFactory sslConnSocketFactory
-                    = new SSLConnectionSocketFactory(buildSslContext(useConfigured));
-            builder.setSSLSocketFactory(sslConnSocketFactory);
+        if (usingSsl) {
+            try {
+                SSLConnectionSocketFactory sslConnSocketFactory
+                        = new SSLConnectionSocketFactory(buildSslContext(useConfigured));
+                builder.setSSLSocketFactory(sslConnSocketFactory);
 
-            Registry<ConnectionSocketFactory> registry
-                    = RegistryBuilder.<ConnectionSocketFactory>create()
-                    .register("https", sslConnSocketFactory)
-                    .build();
+                Registry<ConnectionSocketFactory> registry
+                        = RegistryBuilder.<ConnectionSocketFactory>create()
+                        .register("https", sslConnSocketFactory)
+                        .build();
 
-            HttpClientConnectionManager ccm
-                    = new BasicHttpClientConnectionManager(registry);
+                HttpClientConnectionManager ccm
+                        = new BasicHttpClientConnectionManager(registry);
 
-            builder.setConnectionManager(ccm);
-        } catch (NoSuchAlgorithmException nsae) {
-            throw new RuntimeException("Unable to connect to Jenkins due to algorithm exception", nsae);
-        } catch (KeyManagementException kme) {
-            throw new RuntimeException("Unable to connect to Jenkins due to key management exception", kme);
-        } catch (KeyStoreException kse) {
-            throw new RuntimeException("Unable to connect to Jenkins due to key store exception", kse);
-
+                builder.setConnectionManager(ccm);
+            } catch (NoSuchAlgorithmException nsae) {
+                throw new RuntimeException("Unable to connect to Jenkins due to algorithm exception", nsae);
+            } catch (KeyManagementException kme) {
+                throw new RuntimeException("Unable to connect to Jenkins due to key management exception", kme);
+            } catch (KeyStoreException kse) {
+                throw new RuntimeException("Unable to connect to Jenkins due to key store exception", kse);
+            }
         }
 
         return builder.build();

--- a/src/main/java/com/nerdwin15/stash/webhook/service/HttpClientFactory.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/service/HttpClientFactory.java
@@ -1,5 +1,6 @@
 package com.nerdwin15.stash.webhook.service;
 
+import com.nerdwin15.stash.webhook.ClientKeyStore;
 import org.apache.http.client.HttpClient;
 
 /**
@@ -14,9 +15,10 @@ public interface HttpClientFactory {
    * Generate a HttpClient to communicate with Jenkins.
    * @param usingSsl True if using ssl.
    * @param trustAllCerts True if all certs should be trusted.
+   * @param clientKeyStore
    * @return An HttpClient configured to communicate with Jenkins.
    * @throws Exception Any exception, but shouldn't happen.
    */
-  HttpClient getHttpClient(Boolean usingSsl, Boolean trustAllCerts)
+  HttpClient getHttpClient(Boolean usingSsl, Boolean trustAllCerts, ClientKeyStore clientKeyStore)
       throws Exception;
 }

--- a/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
@@ -88,7 +88,7 @@ public class NotifierTest {
 
     sshCloneUrlResolver = mock(SshCloneUrlResolver.class);
     applicationPropertiesService = mock(ApplicationPropertiesService.class);
-    when(applicationPropertiesService.getPluginProperty(eq("keyStore"))).thenReturn(null);
+    when(applicationPropertiesService.getPluginProperty(eq(ClientKeyStore.KEYSTORE_KEY))).thenReturn(null);
 
     notifier = new Notifier(settingsService, httpClientFactory, navBuilder, securityService, sshCloneUrlResolver, applicationPropertiesService);
 

--- a/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
@@ -1,14 +1,14 @@
 package com.nerdwin15.stash.webhook;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.atlassian.stash.server.ApplicationPropertiesService;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.ClientConnectionManager;
@@ -57,8 +57,9 @@ public class NotifierTest {
   private NavBuilder navBuilder;
   private SecurityService securityService;
   private SshCloneUrlResolver sshCloneUrlResolver;
+  private ApplicationPropertiesService applicationPropertiesService;
 
-  /**
+    /**
    * Setup tasks
    */
   @Before
@@ -86,7 +87,10 @@ public class NotifierTest {
     }
 
     sshCloneUrlResolver = mock(SshCloneUrlResolver.class);
-    notifier = new Notifier(settingsService, httpClientFactory, navBuilder, securityService, sshCloneUrlResolver);
+    applicationPropertiesService = mock(ApplicationPropertiesService.class);
+    when(applicationPropertiesService.getPluginProperty(eq("keyStore"))).thenReturn(null);
+
+    notifier = new Notifier(settingsService, httpClientFactory, navBuilder, securityService, sshCloneUrlResolver, applicationPropertiesService);
 
     repo = mock(Repository.class);
     repoHook = mock(RepositoryHook.class);
@@ -98,20 +102,22 @@ public class NotifierTest {
     when(settingsService.getRepositoryHook(repo)).thenReturn(repoHook);
     when(settingsService.getSettings(repo)).thenReturn(settings);
     when(httpClientFactory
-        .getHttpClient(any(Boolean.class), any(Boolean.class)))
+        .getHttpClient(any(Boolean.class), any(Boolean.class), any(ClientKeyStore.class)))
         .thenReturn(httpClient);
+
     when(httpClient.getConnectionManager()).thenReturn(connectionManager);
 
     NavBuilder.Repo navBuilderRepo = mock(NavBuilder.Repo.class);
     NavBuilder.RepoClone navBuilderRepoClone = mock(NavBuilder.RepoClone.class);
     when(navBuilder.repo(repo)).thenReturn(navBuilderRepo);
-    when(navBuilderRepo.clone("git")).thenReturn(navBuilderRepoClone);
+    when(navBuilderRepo.clone(eq("git"))).thenReturn(navBuilderRepoClone);
     when(navBuilderRepoClone.buildAbsoluteWithoutUsername()).thenReturn(HTTP_CLONE_URL);
 
     when(sshCloneUrlResolver.getCloneUrl(repo)).thenReturn(SSH_CLONE_URL);
 
     when(settings.getString(Notifier.JENKINS_BASE))
       .thenReturn(JENKINS_BASE_URL);
+
     when(settings.getString(Notifier.CLONE_TYPE)).thenReturn("http");
     when(settings.getBoolean(Notifier.IGNORE_CERTS, false)).thenReturn(false);
   }
@@ -125,7 +131,7 @@ public class NotifierTest {
     when(settingsService.getRepositoryHook(repo)).thenReturn(null);
     notifier.notify(repo, "refs/heads/master", "sha1");
     verify(httpClientFactory, never())
-      .getHttpClient(anyBoolean(), anyBoolean());
+      .getHttpClient(anyBoolean(), anyBoolean(), any(ClientKeyStore.class));
   }
 
   /**
@@ -137,7 +143,7 @@ public class NotifierTest {
     when(repoHook.isEnabled()).thenReturn(false);
     notifier.notify(repo, "refs/heads/master", "sha1");
     verify(httpClientFactory, never())
-        .getHttpClient(anyBoolean(), anyBoolean());
+        .getHttpClient(anyBoolean(), anyBoolean(), any(ClientKeyStore.class));
   }
 
   /**
@@ -149,7 +155,7 @@ public class NotifierTest {
     when(settingsService.getSettings(repo)).thenReturn(null);
     notifier.notify(repo, "refs/heads/master", "sha1");
     verify(httpClientFactory, never())
-      .getHttpClient(anyBoolean(), anyBoolean());
+      .getHttpClient(anyBoolean(), anyBoolean(), any(ClientKeyStore.class));
   }
 
   /**
@@ -163,7 +169,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-    verify(httpClientFactory, times(1)).getHttpClient(false, false);
+    verify(httpClientFactory, times(1)).getHttpClient(eq(false), eq(false), any(ClientKeyStore.class));
     verify(httpClient, times(1)).execute(captor.capture());
     verify(connectionManager, times(1)).shutdown();
 
@@ -185,7 +191,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-    verify(httpClientFactory, times(1)).getHttpClient(false, false);
+    verify(httpClientFactory, times(1)).getHttpClient(eq(false), eq(false), any(ClientKeyStore.class));
     verify(httpClient, times(1)).execute(captor.capture());
     verify(connectionManager, times(1)).shutdown();
 
@@ -209,7 +215,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-    verify(httpClientFactory, times(1)).getHttpClient(false, false);
+    verify(httpClientFactory, times(1)).getHttpClient(eq(false), eq(false), any(ClientKeyStore.class));
     verify(httpClient, times(1)).execute(captor.capture());
     verify(connectionManager, times(1)).shutdown();
 
@@ -233,7 +239,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-    verify(httpClientFactory, times(1)).getHttpClient(false, false);
+    verify(httpClientFactory, times(1)).getHttpClient(eq(false), eq(false), any(ClientKeyStore.class));
     verify(httpClient, times(1)).execute(captor.capture());
     verify(connectionManager, times(1)).shutdown();
 
@@ -266,7 +272,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-    verify(httpClientFactory, times(1)).getHttpClient(false, false);
+    verify(httpClientFactory, times(1)).getHttpClient(eq(false), eq(false), any(ClientKeyStore.class));
     verify(httpClient, times(1)).execute(captor.capture());
     verify(connectionManager, times(1)).shutdown();
 
@@ -290,7 +296,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-    verify(httpClientFactory, times(1)).getHttpClient(true, false);
+    verify(httpClientFactory, times(1)).getHttpClient(eq(true), eq(false), any(ClientKeyStore.class));
     verify(httpClient, times(1)).execute(captor.capture());
     verify(connectionManager, times(1)).shutdown();
 
@@ -316,7 +322,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-    verify(httpClientFactory, times(1)).getHttpClient(true, true);
+    verify(httpClientFactory, times(1)).getHttpClient(eq(true), eq(true), any(ClientKeyStore.class));
     verify(httpClient, times(1)).execute(captor.capture());
     verify(connectionManager, times(1)).shutdown();
 
@@ -342,7 +348,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-    verify(httpClientFactory, times(1)).getHttpClient(false, false);
+    verify(httpClientFactory, times(1)).getHttpClient(eq(false), eq(false), any(ClientKeyStore.class));
     verify(httpClient, times(1)).execute(captor.capture());
     verify(connectionManager, times(1)).shutdown();
 
@@ -366,7 +372,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-    verify(httpClientFactory, times(1)).getHttpClient(false, false);
+    verify(httpClientFactory, times(1)).getHttpClient(eq(false), eq(false), any(ClientKeyStore.class));
     verify(httpClient, times(1)).execute(captor.capture());
     verify(connectionManager, times(1)).shutdown();
 
@@ -389,7 +395,7 @@ public class NotifierTest {
 
     ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
 
-   verify(httpClientFactory, times(1)).getHttpClient(false, false);
+   verify(httpClientFactory, times(1)).getHttpClient(eq(false), eq(false), any(ClientKeyStore.class));
    verify(httpClient, times(1)).execute(captor.capture());
    verify(connectionManager, times(1)).shutdown();
 

--- a/src/test/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactoryTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactoryTest.java
@@ -4,11 +4,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.security.KeyManagementException;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
 
 import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.ssl.SSLContextBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,12 +37,10 @@ public class ConcreteHttpClientFactoryTest {
   @Test
   public void validateNonSslGeneration() throws Exception {
     factory.getHttpClient(false, false);
-    assertFalse(factory.wasSslContextCreated());
-    assertFalse(factory.wasSchemeRegistryCreated());
+    assertFalse(factory.ignoreUnverifiedSSL);
 
     factory.getHttpClient(false, true);
-    assertFalse(factory.wasSslContextCreated());
-    assertFalse(factory.wasSchemeRegistryCreated());
+    assertFalse(factory.ignoreUnverifiedSSL);
   }
 
   /**
@@ -49,8 +49,7 @@ public class ConcreteHttpClientFactoryTest {
   @Test
   public void validateUsingDefaultCertificates() throws Exception {
     factory.getHttpClient(true, false);
-    assertFalse(factory.wasSslContextCreated());
-    assertFalse(factory.wasSchemeRegistryCreated());
+    assertFalse(factory.ignoreUnverifiedSSL);
   }
 
   /**
@@ -59,8 +58,7 @@ public class ConcreteHttpClientFactoryTest {
   @Test
   public void validateIgnoringSslCertValidation() throws Exception {
     factory.getHttpClient(true, true);
-    assertTrue(factory.wasSslContextCreated());
-    assertTrue(factory.wasSchemeRegistryCreated());
+    assertTrue(factory.ignoreUnverifiedSSL);
   }
 
   /**
@@ -72,28 +70,13 @@ public class ConcreteHttpClientFactoryTest {
    */
   private class InstrumentedConcreteHttpClientFactory 
       extends ConcreteHttpClientFactory {
-    private boolean sslContextCreated = false;
-    private boolean schemeRegistryCreated = false;
-
-    public boolean wasSchemeRegistryCreated() {
-      return schemeRegistryCreated;
-    }
-
-    public boolean wasSslContextCreated() {
-      return sslContextCreated;
-    }
+    public boolean ignoreUnverifiedSSL = false;
 
     @Override
-    protected SSLContext createContext() throws NoSuchAlgorithmException,
-        KeyManagementException {
-      sslContextCreated = true;
-      return super.createContext();
-    }
-
-    @Override
-    protected SchemeRegistry createScheme(SSLContext sslContext) throws Exception  {
-      schemeRegistryCreated = true;
-      return super.createScheme(sslContext);
+    public SSLContextBuilder ignoreUnverifiedSSL(SSLContextBuilder customContext) throws KeyStoreException, NoSuchAlgorithmException {
+      ignoreUnverifiedSSL = true;
+      return super.ignoreUnverifiedSSL(customContext);
     }
   }
+
 }


### PR DESCRIPTION
We have hit a requirement to secure the Jenkins instance behind client certificates.

For this rather than getting the key material provided by the form it is probably easier to allow that a keystore is provided from the environment in which Stash is running.

This allows the Stash admin to provide a key in a Java keystore and then present that key when we connect to the Jenkins instance.

If you are up for it I'm happy to add more documentation on the approach to the readme
