### PR TITLE
Allow the Trigger Build Button to be enabled or disabled

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/conditions/TriggerBuildButtonEnabledCondition.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/conditions/TriggerBuildButtonEnabledCondition.java
@@ -1,0 +1,55 @@
+package com.nerdwin15.stash.webhook.conditions;
+
+import com.atlassian.plugin.PluginParseException;
+import com.atlassian.plugin.web.Condition;
+import com.atlassian.stash.repository.Repository;
+import com.atlassian.stash.setting.Settings;
+import com.nerdwin15.stash.webhook.service.SettingsService;
+
+import java.util.Map;
+
+/**
+ * Checks whether or not the "Trigger Build Button" on the Pull Requests Overview page should be displayed or not
+ * Created by Stephen Liang
+ */
+public class TriggerBuildButtonEnabledCondition implements Condition {
+
+    private final SettingsService settingsService;
+
+    public static final String OMIT_TRIGGER_BUILD_BUTTON = "omitTriggerBuildButton";
+    public static final String REPOSITORY = "repository";
+
+    public TriggerBuildButtonEnabledCondition(SettingsService settingsService) {
+        this.settingsService = settingsService;
+    }
+
+    @Override
+    public void init(Map<String, String> stringStringMap) throws PluginParseException {
+        // Nothing to do here
+    }
+
+    /**
+     * Checks if we should display the "Trigger Build Button", true by default
+     * @param context Stash Context
+     * @return True by default. False if explicitly disabled
+     */
+    @Override
+    public boolean shouldDisplay(Map<String, Object> context) {
+        final Object obj = context.get(REPOSITORY);
+
+        if (obj == null || !(obj instanceof Repository)) {
+            return true;
+        }
+
+        Repository repo = (Repository) obj;
+
+        Settings settings = settingsService.getSettings(repo);
+
+        if (settings != null) {
+            Boolean shouldOmitTriggerBuildButton = settings.getBoolean(OMIT_TRIGGER_BUILD_BUTTON);
+            return shouldOmitTriggerBuildButton == null ? true : !shouldOmitTriggerBuildButton;
+        }
+
+        return true;
+    }
+}

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -65,12 +65,13 @@
             </condition>
             <condition class="com.atlassian.stash.web.conditions.CanMergePullRequestCondition"/>
             <condition class="com.nerdwin15.stash.webhook.conditions.WebhookIsEnabledCondition" />
+            <condition class="com.nerdwin15.stash.webhook.conditions.TriggerBuildButtonEnabledCondition" />
         </conditions>
         <label key="stash.web.pull-request.toolbar.triggerJenkins">Trigger Build</label>
         <styleClass>triggerJenkinsBuild</styleClass>
         <dependency>${project.groupId}-${project.artifactId}:jenkins-pr-triggerbutton</dependency>
     </web-item>
-    
+
     <web-resource key="jenkins-pr-triggerbutton">
         <resource type="download" name="jenkins-pr-triggerbutton.js" location="/static/jenkins-pr-triggerbutton.js" />
         <dependency>com.atlassian.stash.stash-web-plugin:global</dependency>

--- a/src/main/resources/static/jenkins.soy
+++ b/src/main/resources/static/jenkins.soy
@@ -68,6 +68,18 @@
         {param description: stash_i18n('stash.webhook.omitBranchName.description', 'Do not send the commit\'s branch name to Jenkins') /}
     {/call}
 
+    {call widget.aui.form.checkbox}
+            {param id: 'omitTriggerBuildButton' /}
+            {param checked: $config['omitTriggerBuildButton'] /}
+            {param labelContent}
+                {stash_i18n('stash.webhook.omitTriggerBuildButton.label', 'Omit the Trigger Build Button')}
+            {/param}
+            {param labelHtml}
+                {stash_i18n('stash.webhook.omitTriggerBuildButton.label', 'Omit the Trigger Build Button')}
+            {/param}
+            {param description: stash_i18n('stash.webhook.omitTriggerBuildButton.description', 'Do not display the Trigger Build Button on the pull request overview page') /}
+    {/call}
+
     {call widget.aui.form.field}
         {param id: 'test-form' /}
         {param labelContent: stash_i18n('stash.webhook.test', 'Configuration check') /}

--- a/src/test/java/com/nerdwin15/stash/webhook/conditions/TriggerBuildButtonEnabledConditionTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/conditions/TriggerBuildButtonEnabledConditionTest.java
@@ -1,0 +1,102 @@
+package com.nerdwin15.stash.webhook.conditions;
+
+import com.atlassian.stash.repository.Repository;
+import com.atlassian.stash.setting.Settings;
+import com.nerdwin15.stash.webhook.service.SettingsService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static com.nerdwin15.stash.webhook.conditions.TriggerBuildButtonEnabledCondition.REPOSITORY;
+import static com.nerdwin15.stash.webhook.conditions.TriggerBuildButtonEnabledCondition.OMIT_TRIGGER_BUILD_BUTTON;
+import static org.mockito.Mockito.when;
+
+public class TriggerBuildButtonEnabledConditionTest {
+    @Mock
+    private SettingsService settingsService;
+    @Mock
+    private Repository repository;
+    @Mock
+    private Settings settings;
+
+    private TriggerBuildButtonEnabledCondition triggerBuildButtonEnabledCondition;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        triggerBuildButtonEnabledCondition = new TriggerBuildButtonEnabledCondition(settingsService);
+    }
+
+    @Test
+    public void testShouldDisplayButObjIsNull() throws Exception {
+        Map<String, Object> context = new HashMap<String, Object>();
+        boolean result = triggerBuildButtonEnabledCondition.shouldDisplay(context);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testShouldDisplayButObjIsNotARepository() throws Exception {
+        Map<String, Object> context = new HashMap<String, Object>();
+        context.put(REPOSITORY, "");
+        boolean result = triggerBuildButtonEnabledCondition.shouldDisplay(context);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testShouldDisplayButSettingServiceReturnedNull() throws Exception {
+        Map<String, Object> context = new HashMap<String, Object>();
+        context.put(REPOSITORY, repository);
+
+        when(settingsService.getSettings(repository)).thenReturn(null);
+
+        boolean result = triggerBuildButtonEnabledCondition.shouldDisplay(context);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testShouldDisplayButNotEnabled() throws Exception {
+        Map<String, Object> context = new HashMap<String, Object>();
+        context.put(REPOSITORY, repository);
+
+        when(settingsService.getSettings(repository)).thenReturn(settings);
+        when(settings.getBoolean(OMIT_TRIGGER_BUILD_BUTTON)).thenReturn(true);
+
+        boolean result = triggerBuildButtonEnabledCondition.shouldDisplay(context);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testShouldDisplayButNull() throws Exception {
+        Map<String, Object> context = new HashMap<String, Object>();
+        context.put(REPOSITORY, repository);
+
+        when(settingsService.getSettings(repository)).thenReturn(settings);
+        when(settings.getBoolean(OMIT_TRIGGER_BUILD_BUTTON)).thenReturn(null);
+
+        boolean result = triggerBuildButtonEnabledCondition.shouldDisplay(context);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testShouldDisplayEnabled() throws Exception {
+        Map<String, Object> context = new HashMap<String, Object>();
+        context.put(REPOSITORY, repository);
+
+        when(settingsService.getSettings(repository)).thenReturn(settings);
+        when(settings.getBoolean(OMIT_TRIGGER_BUILD_BUTTON)).thenReturn(false);
+
+        boolean result = triggerBuildButtonEnabledCondition.shouldDisplay(context);
+
+        assertTrue(result);
+    }
+}


### PR DESCRIPTION
We have a use case where we don't want the "Trigger Build" button to be shown. As such, this PR will allow the button to be enabled or disabled. (Enabled by default)