### PR TITLE
add editorconfig for .java-files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.java]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true


### PR DESCRIPTION
You use 2 spaces to indent in java-files. I added a .editorconfig to configure most IDEs to do the same.

See: http://editorconfig.org/