### PR TITLE
Fix sha1 for test-trigger

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
@@ -261,7 +261,7 @@ public class Notifier implements DisposableBean {
 
     if(strRef != null && !omitBranchName)
       url.append(String.format(BRANCH_URL_PARAMETER, urlEncode(strRef)));
-    if(!omitHashCode)
+    if(strSha1 != null && !omitHashCode)
       url.append(String.format(HASH_URL_PARAMETER, strSha1));
 
     return url.toString();

--- a/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
@@ -85,6 +85,7 @@ public class JenkinsResource extends RestResource {
    * @param cloneUrl The url used for repository cloning
    * @param ignoreCerts True if all certs should be accepted.
    * @param omitHashCode True if SHA1 hash should be omitted.
+   * @param omitBranchName True if branch name should be omitted.
    * @return The response to send back to the user.
    */
   @POST
@@ -95,7 +96,8 @@ public class JenkinsResource extends RestResource {
         @FormParam(Notifier.CLONE_TYPE) String cloneType,
         @FormParam(Notifier.CLONE_URL) String cloneUrl,
         @FormParam(Notifier.IGNORE_CERTS) boolean ignoreCerts,
-        @FormParam(Notifier.OMIT_HASH_CODE) boolean omitHashCode) {
+        @FormParam(Notifier.OMIT_HASH_CODE) boolean omitHashCode,
+        @FormParam(Notifier.OMIT_BRANCH_NAME) boolean omitBranchName) {
 
     if (jenkinsBase == null || cloneType == null || (cloneType.equals("custom") && cloneUrl == null)) {
       Map<String, Object> map = new HashMap<String, Object>();
@@ -112,7 +114,7 @@ public class JenkinsResource extends RestResource {
     Branch defaultBranch = refService.getDefaultBranch(repository);
     NotificationResult result = notifier.notify(repository, jenkinsBase,
         ignoreCerts, cloneType, cloneUrl, defaultBranch.getDisplayId(),
-        defaultBranch.getLatestCommit(), omitHashCode, true);
+        defaultBranch.getLatestCommit(), omitHashCode, omitBranchName);
     log.debug("Got response from jenkins: {}", result);
 
     // Shouldn't have to do this but the result isn't being marshalled correctly

--- a/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/rest/JenkinsResource.java
@@ -3,6 +3,8 @@ package com.nerdwin15.stash.webhook.rest;
 import com.atlassian.bitbucket.i18n.I18nService;
 import com.atlassian.bitbucket.permission.Permission;
 import com.atlassian.bitbucket.permission.PermissionValidationService;
+import com.atlassian.bitbucket.repository.Branch;
+import com.atlassian.bitbucket.repository.RefService;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.bitbucket.rest.RestResource;
 import com.atlassian.bitbucket.rest.util.ResourcePatterns;
@@ -28,7 +30,7 @@ import java.util.Map;
 
 /**
  * REST resource used to test the Jenkins configuration
- * 
+ *
  * @author Peter Leibiger (kuhnroyal)
  * @author Michael Irwin (mikesir87)
  */
@@ -47,28 +49,32 @@ public class JenkinsResource extends RestResource {
   private final SshConfigurationService sshConfigurationService;
   private final SshScmProtocol sshScmProtocol;
   private final HttpScmProtocol httpScmProtocol;
+  private final RefService refService;
 
-    /**
+  /**
    * Creates Rest resource for testing the Jenkins configuration
    * @param notifier The service to send Jenkins notifications
-   * @param permissionValidationService A permission validation service 
+   * @param permissionValidationService A permission validation service
    * @param i18nService i18n Service
    * @param sshConfigurationService Service to check whether SSH is enabled
    * @param sshScmProtocol Resolver for generating default SSH clone url
    * @param httpScmProtocol Resolver for generating default http clone url
+   * @param refService Service to get default Branch
    */
   public JenkinsResource(Notifier notifier,
                          PermissionValidationService permissionValidationService,
                          I18nService i18nService,
                          SshConfigurationService sshConfigurationService,
                          SshScmProtocol sshScmProtocol,
-                         HttpScmProtocol httpScmProtocol) {
+                         HttpScmProtocol httpScmProtocol,
+                         RefService refService) {
     super(i18nService);
     this.notifier = notifier;
     this.permissionService = permissionValidationService;
     this.sshConfigurationService = sshConfigurationService;
     this.sshScmProtocol = sshScmProtocol;
     this.httpScmProtocol = httpScmProtocol;
+    this.refService = refService;
   }
 
   /**
@@ -90,7 +96,7 @@ public class JenkinsResource extends RestResource {
         @FormParam(Notifier.CLONE_URL) String cloneUrl,
         @FormParam(Notifier.IGNORE_CERTS) boolean ignoreCerts,
         @FormParam(Notifier.OMIT_HASH_CODE) boolean omitHashCode) {
-    
+
     if (jenkinsBase == null || cloneType == null || (cloneType.equals("custom") && cloneUrl == null)) {
       Map<String, Object> map = new HashMap<String, Object>();
       map.put("successful", false);
@@ -99,14 +105,14 @@ public class JenkinsResource extends RestResource {
     }
 
     permissionService.validateForRepository(repository, Permission.REPO_ADMIN);
-    log.debug("Triggering jenkins notification for repository {}/{}", 
+    log.debug("Triggering jenkins notification for repository {}/{}",
         repository.getProject().getKey(), repository.getSlug());
 
-    /* @todo carl.loa.odin@klarna.com: Send null instead of master and sha1 and
-     *   handle this in notify
-     */
-    NotificationResult result = notifier.notify(repository, jenkinsBase, 
-        ignoreCerts, cloneType, cloneUrl, null, null, omitHashCode, true);
+    // use default branch for test
+    Branch defaultBranch = refService.getDefaultBranch(repository);
+    NotificationResult result = notifier.notify(repository, jenkinsBase,
+        ignoreCerts, cloneType, cloneUrl, defaultBranch.getDisplayId(),
+        defaultBranch.getLatestCommit(), omitHashCode, true);
     log.debug("Got response from jenkins: {}", result);
 
     // Shouldn't have to do this but the result isn't being marshalled correctly
@@ -116,7 +122,7 @@ public class JenkinsResource extends RestResource {
     map.put("message", result.getMessage());
     return map;
   }
-  
+
   /**
    * Trigger a build on the Jenkins instance
    * @param repository The repository to trigger
@@ -138,7 +144,7 @@ public class JenkinsResource extends RestResource {
           .entity(e.getMessage()).build();
     }
   }
-  
+
   /**
    * Get the default clone urls for a repository.
    * @param repository The repository to get clone urls for

--- a/src/main/resources/static/jenkins.js
+++ b/src/main/resources/static/jenkins.js
@@ -19,6 +19,7 @@ define('plugin/jenkins/test', [
             $cloneType = $("#cloneType"),
             $ignoreCerts = $("#ignoreCerts"),
             $omitHashCode = $("#omitHashCode"),
+            $omitBranchName = $("#omitBranchName"),
             $status,
             defaultUrls;
 
@@ -85,7 +86,8 @@ define('plugin/jenkins/test', [
                     'cloneType': [$cloneType.val()],
                     'gitRepoUrl': [$cloneUrl.val()],
                     'ignoreCerts': [$ignoreCerts.attr('checked') ? "TRUE" : "FALSE"],
-                    'omitHashCode': [$omitHashCode.attr('checked') ? "TRUE" : "FALSE"]
+                    'omitHashCode': [$omitHashCode.attr('checked') ? "TRUE" : "FALSE"],
+                    'omitBranchName': [$omitBranchName.attr('checked') ? "TRUE" : "FALSE"]
                 }
             }).always(function () {
                 setDeleteButtonEnabled(true)

--- a/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/NotifierTest.java
@@ -396,4 +396,25 @@ public class NotifierTest {
        captor.getValue().getURI().toString());
   }
 
+  /**
+   * Validates that the correct path is used when the sha1 is null
+   * @throws Exception
+   */
+  @Test
+  public void shouldCallTheCorrectURLWhenSha1IsNull()
+    throws Exception {
+    when(settings.getBoolean(Notifier.OMIT_BRANCH_NAME, false)).thenReturn(false);
+    notifier.notify(repo, "refs/heads/master", null);
+
+    ArgumentCaptor<HttpGet> captor = ArgumentCaptor.forClass(HttpGet.class);
+
+    verify(httpClientFactory, times(1)).getHttpClient(false, false);
+    verify(httpClient, times(1)).execute(captor.capture());
+    verify(connectionManager, times(1)).shutdown();
+
+    assertEquals("http://localhost.jenkins/git/notifyCommit?"
+        + "url=http%3A%2F%2Fsome.stash.com%2Fscm%2Ffoo%2Fbar.git"
+        + "&branches=refs%2Fheads%2Fmaster",
+        captor.getValue().getURI().toString());
+  }
 }

--- a/src/test/java/com/nerdwin15/stash/webhook/rest/JenkinsResourceTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/rest/JenkinsResourceTest.java
@@ -40,6 +40,7 @@ public class JenkinsResourceTest {
   private static final String CLONE_TYPE = "http";
   private static final boolean IGNORE_CERTS = false;
   private static final boolean OMIT_HASH_CODE = false;
+  private static final boolean OMIT_BRANCH_NAME = false;
 
   private static final String HTTP_URL =
       "https://stash.localhost/stash/scm/test/test.git";
@@ -96,13 +97,13 @@ public class JenkinsResourceTest {
 
     NotificationResult notificationResult = mock(NotificationResult.class);
     when(notifier.notify(repository, JENKINS_BASE, IGNORE_CERTS,
-      CLONE_TYPE, HTTP_URL, "master", "anySha1OfLatestCommit", OMIT_HASH_CODE, true))
-      .thenReturn(notificationResult);
+      CLONE_TYPE, HTTP_URL, "master", "anySha1OfLatestCommit",
+      OMIT_HASH_CODE, OMIT_BRANCH_NAME)).thenReturn(notificationResult);
     when(notificationResult.isSuccessful()).thenReturn(true);
 
     Map<String, Object> result =
       resource.test(repository, JENKINS_BASE, CLONE_TYPE, HTTP_URL,
-        IGNORE_CERTS, OMIT_HASH_CODE);
+        IGNORE_CERTS, OMIT_HASH_CODE, OMIT_BRANCH_NAME);
     assertTrue((Boolean) result.get("successful"));
   }
 
@@ -112,7 +113,8 @@ public class JenkinsResourceTest {
   @Test
   public void shouldFailWhenJenkinsBaseNullProvidedToTest() {
     Map<String, Object> result =
-        resource.test(repository, null, CLONE_TYPE, null, IGNORE_CERTS, OMIT_HASH_CODE);
+        resource.test(repository, null, CLONE_TYPE, null, IGNORE_CERTS,
+          OMIT_HASH_CODE, OMIT_BRANCH_NAME);
     assertFalse((Boolean) result.get("successful"));
   }
 
@@ -122,7 +124,8 @@ public class JenkinsResourceTest {
   @Test
   public void shouldFailWhenCloneTypeNullProvidedToTest() {
     Map<String, Object> result =
-        resource.test(repository, JENKINS_BASE, null, HTTP_URL, IGNORE_CERTS, OMIT_HASH_CODE);
+        resource.test(repository, JENKINS_BASE, null, HTTP_URL, IGNORE_CERTS,
+          OMIT_HASH_CODE,OMIT_BRANCH_NAME);
     assertFalse((Boolean) result.get("successful"));
   }
 
@@ -133,7 +136,8 @@ public class JenkinsResourceTest {
   @Test
   public void shouldFailWhenCloneUrlNullProvidedToTest() {
     Map<String, Object> result =
-        resource.test(repository, JENKINS_BASE, "custom", null, IGNORE_CERTS, OMIT_HASH_CODE);
+        resource.test(repository, JENKINS_BASE, "custom", null, IGNORE_CERTS,
+          OMIT_HASH_CODE, OMIT_BRANCH_NAME);
     assertFalse((Boolean) result.get("successful"));
   }
 

--- a/src/test/java/com/nerdwin15/stash/webhook/rest/JenkinsResourceTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/rest/JenkinsResourceTest.java
@@ -2,6 +2,7 @@ package com.nerdwin15.stash.webhook.rest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -18,41 +19,45 @@ import org.junit.Test;
 
 import com.atlassian.bitbucket.i18n.I18nService;
 import com.atlassian.bitbucket.project.Project;
+import com.atlassian.bitbucket.repository.Branch;
+import com.atlassian.bitbucket.repository.RefService;
 import com.atlassian.bitbucket.repository.Repository;
 import com.atlassian.bitbucket.ssh.SshConfiguration;
 import com.atlassian.bitbucket.ssh.SshConfigurationService;
 import com.atlassian.bitbucket.permission.PermissionValidationService;
+import com.nerdwin15.stash.webhook.NotificationResult;
 import com.nerdwin15.stash.webhook.Notifier;
 import com.sun.jersey.api.client.ClientResponse.Status;
 
 /**
  * Test case for the JenkinsResource class.
- * 
+ *
  * @author Michael Irwin (mikesir87)
  */
 public class JenkinsResourceTest {
 
   private static final String JENKINS_BASE = "http://jenkins.localhost/jenkins";
+  private static final String CLONE_TYPE = "http";
   private static final boolean IGNORE_CERTS = false;
   private static final boolean OMIT_HASH_CODE = false;
 
-  private static final String HTTP_URL = 
+  private static final String HTTP_URL =
       "https://stash.localhost/stash/scm/test/test.git";
-  private static final String SSH_URL = 
+  private static final String SSH_URL =
       "ssh://git@stash.localhost:7999/test/test.git";
   private static final String EMPTY_SSH_URL = "";
-  
+
   private JenkinsResource resource;
-  private Notifier notifier; 
-  private PermissionValidationService permissionValidationService; 
+  private Notifier notifier;
+  private PermissionValidationService permissionValidationService;
   private I18nService i18nService;
   private SshConfigurationService sshConfigurationService;
   private SshScmProtocol sshScmProtocol;
   private HttpScmProtocol httpScmProtocol;
-
+  private RefService refService;
 
   private Repository repository;
-  
+
   /**
    * Setup tasks
    */
@@ -65,10 +70,13 @@ public class JenkinsResourceTest {
 
     sshScmProtocol = mock(SshScmProtocol.class);
     httpScmProtocol = mock(HttpScmProtocol.class);
-    
-    resource = new JenkinsResource(notifier, permissionValidationService, 
-        i18nService, sshConfigurationService, sshScmProtocol, httpScmProtocol);
-    
+
+    refService = mock(RefService.class);
+
+    resource = new JenkinsResource(notifier, permissionValidationService,
+        i18nService, sshConfigurationService, sshScmProtocol, httpScmProtocol,
+        refService);
+
     repository = mock(Repository.class);
     Project project = mock(Project.class);
     when(repository.getProject()).thenReturn(project);
@@ -77,12 +85,34 @@ public class JenkinsResourceTest {
   }
 
   /**
+   * Use latest commit on default branch for test-trigger
+   */
+  @Test
+  public void shouldUseDefaultBranchToTest() {
+    Branch defaultBranch = mock(Branch.class);
+    when(refService.getDefaultBranch(repository)).thenReturn(defaultBranch);
+    when(defaultBranch.getDisplayId()).thenReturn("master");
+    when(defaultBranch.getLatestCommit()).thenReturn("anySha1OfLatestCommit");
+
+    NotificationResult notificationResult = mock(NotificationResult.class);
+    when(notifier.notify(repository, JENKINS_BASE, IGNORE_CERTS,
+      CLONE_TYPE, HTTP_URL, "master", "anySha1OfLatestCommit", OMIT_HASH_CODE, true))
+      .thenReturn(notificationResult);
+    when(notificationResult.isSuccessful()).thenReturn(true);
+
+    Map<String, Object> result =
+      resource.test(repository, JENKINS_BASE, CLONE_TYPE, HTTP_URL,
+        IGNORE_CERTS, OMIT_HASH_CODE);
+    assertTrue((Boolean) result.get("successful"));
+  }
+
+  /**
    * Validate that if a null JenkinsBase is provided, a BAD_REQUEST is returned.
    */
   @Test
   public void shouldFailWhenJenkinsBaseNullProvidedToTest() {
-    Map<String, Object> result = 
-        resource.test(repository, null, "http", null, IGNORE_CERTS, OMIT_HASH_CODE);
+    Map<String, Object> result =
+        resource.test(repository, null, CLONE_TYPE, null, IGNORE_CERTS, OMIT_HASH_CODE);
     assertFalse((Boolean) result.get("successful"));
   }
 
@@ -97,16 +127,16 @@ public class JenkinsResourceTest {
   }
 
   /**
-   * Validate that if a null repo clone url is provided when the clone type 
+   * Validate that if a null repo clone url is provided when the clone type
    * is set to CUSTOM, then a BAD_REQUEST is returned.
    */
   @Test
   public void shouldFailWhenCloneUrlNullProvidedToTest() {
-    Map<String, Object> result = 
+    Map<String, Object> result =
         resource.test(repository, JENKINS_BASE, "custom", null, IGNORE_CERTS, OMIT_HASH_CODE);
     assertFalse((Boolean) result.get("successful"));
   }
-  
+
   /**
    * Validate that the config endpoint creates the expected results.
    */
@@ -114,23 +144,23 @@ public class JenkinsResourceTest {
   @SuppressWarnings("unchecked")
   public void testConfigResource() {
     when(httpScmProtocol.getCloneUrl(repository, null)).thenReturn(HTTP_URL);
-    
+
     SshConfiguration sshConfiguration = mock(SshConfiguration.class);
-    
+
     when(sshConfigurationService.getConfiguration()).thenReturn(sshConfiguration);
     when(sshConfiguration.isEnabled()).thenReturn(true);
     when(sshScmProtocol.getCloneUrl(repository, null)).thenReturn(SSH_URL);
-    
+
     Response response = resource.config(repository);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
     Map<String, String> data = (Map<String, String>) response.getEntity();
     assertEquals(data.get("ssh"), SSH_URL);
     assertEquals(data.get("http"), HTTP_URL);
-    
+
     verify(sshScmProtocol).getCloneUrl(repository, null);
     verify(httpScmProtocol).getCloneUrl(repository, null);
   }
-  
+
   /**
    * Validate that the config endpoint safely handles the case when the internal SSH
    * server is disabled in Stash 3.0 and later.
@@ -145,15 +175,15 @@ public class JenkinsResourceTest {
     when(sshConfiguration.isEnabled()).thenReturn(false);
     when(sshScmProtocol.getCloneUrl(repository, null)).thenThrow(
             new IllegalStateException("Internal SSH server is disabled"));
-    
+
     Response response = resource.config(repository);
     assertEquals(Status.OK.getStatusCode(), response.getStatus());
     Map<String, String> data = (Map<String, String>) response.getEntity();
     assertEquals(data.get("ssh"), EMPTY_SSH_URL);
     assertEquals(data.get("http"), HTTP_URL);
-    
+
     verify(sshScmProtocol, never()).getCloneUrl(repository, null);
     verify(httpScmProtocol).getCloneUrl(repository, null);
   }
-  
+
 }


### PR DESCRIPTION
This fixes #134

I also use the branch name of the default branch, if omitBranchName is not active.