### PR TITLE
Allows all hostnames when trusting all certificates

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactory.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactory.java
@@ -93,8 +93,9 @@ public class ConcreteHttpClientFactory implements HttpClientFactory {
   protected SchemeRegistry createScheme(SSLContext sslContext) 
       throws Exception {
     SchemeRegistry schemeRegistry = new SchemeRegistry();
-    schemeRegistry.register(
-        new Scheme("https", HTTPS_PORT, new SSLSocketFactory(sslContext)));
+    SSLSocketFactory socketFactory = new SSLSocketFactory(sslContext);
+    socketFactory.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+    schemeRegistry.register(new Scheme("https", HTTPS_PORT, socketFactory));
     schemeRegistry.register(
         new Scheme("http", HTTP_PORT, PlainSocketFactory.getSocketFactory()));
     return schemeRegistry;


### PR DESCRIPTION
The SNI issue present in the plugin (the wrong certificate is presented when
calling to a Jenkins URL running HTTPS which hosts multiple domains via e.g. a loadbalancer) cannot
be handled by just skipping SSL Certificate validation. We also need to skip the hostname-verification. Therefore a fix allowing all hostnames when skipping the SSL Certificate is added to circumvent
the hostname check before the certificate is ignored.