### PR TITLE
Fix broken api use for bitbucket server 5.0.0

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteBranchEvaluator.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteBranchEvaluator.java
@@ -11,7 +11,7 @@ import com.google.common.collect.Iterables;
 /**
  * A concrete implementation of the {@link BranchEvaluator} that uses sample
  * code from the Atlassian stash-webhook-plugin:
- * 
+ *
  * https://bitbucket.org/atlassian/stash-webhook-plugin/src/a18713fad2959e670e355df64c840b79a806d8ab/src/main/java/com/atlassian/stash/plugin/webook/WebHook.java?at=master
  *
  * @author Michael Irwin (mikesir87)
@@ -31,13 +31,13 @@ public class ConcreteBranchEvaluator implements BranchEvaluator {
           public boolean apply(RefChange input) {
             // We only care about non-deleted branches
             return input.getType() != RefChangeType.DELETE
-                && input.getRefId().startsWith(REFS_HEADS);
+                && input.getRef().getId().startsWith(REFS_HEADS);
           }
         }), new Function<RefChange, String>() {
           @Override
           public String apply(RefChange input) {
             // Not 100% sure whether this is _just_ branch or is full ref?
-            return input.getRefId().replace(REFS_HEADS, "");
+            return input.getRef().getId().replace(REFS_HEADS, "");
           }
         });
   }


### PR DESCRIPTION
This is not a 5.0.0 release version, just fixes the broken use of getRefId (changes to getRef().getId() which is incompatible with Bitbucket 5.0.0