### PR TITLE
Enable SNI

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactory.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactory.java
@@ -22,10 +22,10 @@ import org.apache.http.impl.conn.ProxySelectorRoutePlanner;
  * DefaultHttpClient that is either not configured at all (non-ssl and default
  * trusts) or configured to accept all certificates.  If told to accept all
  * certificates, an unsafe X509 trust manager is used.
- * 
+ *
  * If setup of the "trust-all" HttpClient fails, a non-configured HttpClient
  * is returned.
- * 
+ *
  * @author Michael Irwin (mikesir87)
  *
  */
@@ -33,12 +33,12 @@ public class ConcreteHttpClientFactory implements HttpClientFactory {
 
   private static final Integer HTTP_PORT = 80;
   private static final Integer HTTPS_PORT = 443;
-  
+
   /**
    * {@inheritDoc}
    */
   @Override
-  public HttpClient getHttpClient(Boolean usingSsl, Boolean trustAllCerts) 
+  public HttpClient getHttpClient(Boolean usingSsl, Boolean trustAllCerts)
       throws Exception {
     return createHttpClient(usingSsl && trustAllCerts);
   }
@@ -74,12 +74,12 @@ public class ConcreteHttpClientFactory implements HttpClientFactory {
    * @throws NoSuchAlgorithmException
    * @throws KeyManagementException
    */
-  protected SSLContext createContext() throws NoSuchAlgorithmException, 
+  protected SSLContext createContext() throws NoSuchAlgorithmException,
       KeyManagementException {
     SSLContext sslContext = SSLContext.getInstance("TLS");
     sslContext.init(
-        null, 
-        new TrustManager[] { new UnsafeX509TrustManager() }, 
+        null,
+        new TrustManager[] { new UnsafeX509TrustManager() },
         new SecureRandom());
     return sslContext;
   }

--- a/src/main/resources/static/jenkins.js
+++ b/src/main/resources/static/jenkins.js
@@ -33,9 +33,9 @@ define('plugin/jenkins/test', [
 
         function setDeleteButtonEnabled(enabled) {
             if (enabled) {
-                $button.removeProp("disabled").removeClass("disabled");
+                $button.removeAttr("disabled").removeClass("disabled");
             } else {
-                $button.prop("disabled", "disabled").addClass("disabled");
+                $button.attr("disabled", "disabled").addClass("disabled");
             }
         }
 

--- a/src/main/resources/static/jenkins.js
+++ b/src/main/resources/static/jenkins.js
@@ -42,12 +42,12 @@ define('plugin/jenkins/test', [
         function setCloneUrl(val) {
             if (val == "ssh") {
         		$cloneUrl.val( defaultUrls.ssh );
-                $cloneUrl.prop("disabled", "disabled").addClass("disabled");
+                $cloneUrl.attr("disabled", "disabled").addClass("disabled");
         	} else if (val == "http") {
         		$cloneUrl.val( defaultUrls.http );
-                $cloneUrl.prop("disabled", "disabled").addClass("disabled");
+                $cloneUrl.attr("disabled", "disabled").addClass("disabled");
         	} else {
-                $cloneUrl.removeProp("disabled").removeClass("disabled");
+                $cloneUrl.removeAttr("disabled").removeClass("disabled");
             }
         }
 

--- a/src/test/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactoryTest.java
+++ b/src/test/java/com/nerdwin15/stash/webhook/service/ConcreteHttpClientFactoryTest.java
@@ -8,7 +8,8 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.config.Registry;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -91,9 +92,9 @@ public class ConcreteHttpClientFactoryTest {
     }
 
     @Override
-    protected SchemeRegistry createScheme(SSLContext sslContext) throws Exception  {
+    protected Registry<ConnectionSocketFactory> createRegistry(SSLContext sslContext) throws Exception  {
       schemeRegistryCreated = true;
-      return super.createScheme(sslContext);
+      return super.createRegistry(sslContext);
     }
   }
 }


### PR DESCRIPTION
fixes #104 (although not by upgrading SNI, but by using the new API introduced in httpclient 4.3 instead of the deprecated ones).

This also includes minor fixes in the Javascript for the connection test, because it annoyed me while testing this 😄 .

I also took the freedom to disable host name checking when ticking "Skip SSL Certificate Validation" (also see #176), because it made sense to me. Please let me know if this should be an extra pull request and/or configurable on its own.