### PR TITLE
fix request action logging

### DIFF
--- a/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
+++ b/src/main/java/com/nerdwin15/stash/webhook/Notifier.java
@@ -17,6 +17,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.DisposableBean;
 
 import javax.annotation.Nonnull;
@@ -25,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -135,9 +137,11 @@ public class Notifier implements DisposableBean {
   @Nonnull
   public Future<NotificationResult> notifyBackground(@Nonnull final Repository repo, //CHECKSTYLE:annot
       final String strRef, final String strSha1) {
+    final Map<String, String> contextMap = MDC.getCopyOfContextMap();
     return executorService.submit(new Callable<NotificationResult>() {
       @Override
       public NotificationResult call() throws Exception {
+        MDC.setContextMap(contextMap);
         return Notifier.this.notify(repo, strRef, strSha1);
       }
     });


### PR DESCRIPTION
Problem:
If a lot of commits are pushed to different repos that all
have the hook installed,
the bitbucket log may contain entries like the following one.
Here the request logged is for the rep_1 repository,
while the notification URL is for the rep_2 repository:

2017-07-12 16:22:14,009 ERROR [JenkinsWebhook:thread-1353] user@example.com @1NT5XEPx981x8325789x2 1oo66tb 127.0.0.1 SSH - git-receive-pack '/project_1/rep_1.git' com.nerdwin15.stash.webhook.Notifier Error triggering jenkins with url 'http://localhost:8080/jenkins/git/notifyCommit?url=http%3A%2F%2Flocalhost%3A7990%2Fbitbucket%2Fscm%2Fproject_2%2Frep_2.git'

(this one only occurs when the hook runs into an error,
but similar ones can be found for succesful requests
when setting the com.nerdwin15.stash logger to DEBUG)

This is caused by the fact that we are running in a thread pool,
and the original request that caused this (that was run in a different thread)
is not correctly associated in the MDC map of logback.

Fix:
Tell logback about the original request manually.

See
https://stackoverflow.com/questions/6073019/how-to-use-mdc-with-thread-pools#19329668
https://logback.qos.ch/manual/mdc.html#managedThreads

Also see
https://jira.atlassian.com/browse/BSERV-8749